### PR TITLE
Remove json tags from embedded structs

### DIFF
--- a/scripts/struct2go2.pl
+++ b/scripts/struct2go2.pl
@@ -14,7 +14,7 @@ while(<>) {
     $in_struct = 1;
     $t = $1;
     $lct = lc $t;
-    $annotation = $o ? "" : qq{`xml:"$t" json:"$t"`};
+    $annotation = $o ? "" : qq{`xml:"$t"`};
     print << "END";
   $lct $annotation
 }

--- a/sifxml/Activity.go
+++ b/sifxml/Activity.go
@@ -4,7 +4,7 @@ package sifxml
 type Activitys []Activity
 
     type Activity struct {
-  activity `xml:"Activity" json:"Activity"`
+  activity `xml:"Activity"`
 }
 
 type activity struct {

--- a/sifxml/AddressCollection.go
+++ b/sifxml/AddressCollection.go
@@ -4,7 +4,7 @@ package sifxml
 type AddressCollections []AddressCollection
 
     type AddressCollection struct {
-  addresscollection `xml:"AddressCollection" json:"AddressCollection"`
+  addresscollection `xml:"AddressCollection"`
 }
 
 type addresscollection struct {

--- a/sifxml/AggregateCharacteristicInfo.go
+++ b/sifxml/AggregateCharacteristicInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type AggregateCharacteristicInfos []AggregateCharacteristicInfo
 
     type AggregateCharacteristicInfo struct {
-  aggregatecharacteristicinfo `xml:"AggregateCharacteristicInfo" json:"AggregateCharacteristicInfo"`
+  aggregatecharacteristicinfo `xml:"AggregateCharacteristicInfo"`
 }
 
 type aggregatecharacteristicinfo struct {

--- a/sifxml/AggregateStatisticFact.go
+++ b/sifxml/AggregateStatisticFact.go
@@ -4,7 +4,7 @@ package sifxml
 type AggregateStatisticFacts []AggregateStatisticFact
 
     type AggregateStatisticFact struct {
-  aggregatestatisticfact `xml:"AggregateStatisticFact" json:"AggregateStatisticFact"`
+  aggregatestatisticfact `xml:"AggregateStatisticFact"`
 }
 
 type aggregatestatisticfact struct {

--- a/sifxml/AggregateStatisticInfo.go
+++ b/sifxml/AggregateStatisticInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type AggregateStatisticInfos []AggregateStatisticInfo
 
     type AggregateStatisticInfo struct {
-  aggregatestatisticinfo `xml:"AggregateStatisticInfo" json:"AggregateStatisticInfo"`
+  aggregatestatisticinfo `xml:"AggregateStatisticInfo"`
 }
 
 type aggregatestatisticinfo struct {

--- a/sifxml/CalendarDate.go
+++ b/sifxml/CalendarDate.go
@@ -4,7 +4,7 @@ package sifxml
 type CalendarDates []CalendarDate
 
     type CalendarDate struct {
-  calendardate `xml:"CalendarDate" json:"CalendarDate"`
+  calendardate `xml:"CalendarDate"`
 }
 
 type calendardate struct {

--- a/sifxml/CalendarSummary.go
+++ b/sifxml/CalendarSummary.go
@@ -4,7 +4,7 @@ package sifxml
 type CalendarSummarys []CalendarSummary
 
     type CalendarSummary struct {
-  calendarsummary `xml:"CalendarSummary" json:"CalendarSummary"`
+  calendarsummary `xml:"CalendarSummary"`
 }
 
 type calendarsummary struct {

--- a/sifxml/CensusCollection.go
+++ b/sifxml/CensusCollection.go
@@ -4,7 +4,7 @@ package sifxml
 type CensusCollections []CensusCollection
 
     type CensusCollection struct {
-  censuscollection `xml:"CensusCollection" json:"CensusCollection"`
+  censuscollection `xml:"CensusCollection"`
 }
 
 type censuscollection struct {

--- a/sifxml/ChargedLocationInfo.go
+++ b/sifxml/ChargedLocationInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type ChargedLocationInfos []ChargedLocationInfo
 
     type ChargedLocationInfo struct {
-  chargedlocationinfo `xml:"ChargedLocationInfo" json:"ChargedLocationInfo"`
+  chargedlocationinfo `xml:"ChargedLocationInfo"`
 }
 
 type chargedlocationinfo struct {

--- a/sifxml/CollectionAcquittal.go
+++ b/sifxml/CollectionAcquittal.go
@@ -4,7 +4,7 @@ package sifxml
 type CollectionAcquittals []CollectionAcquittal
 
     type CollectionAcquittal struct {
-  collectionacquittal `xml:"CollectionAcquittal" json:"CollectionAcquittal"`
+  collectionacquittal `xml:"CollectionAcquittal"`
 }
 
 type collectionacquittal struct {

--- a/sifxml/CollectionDeclaration.go
+++ b/sifxml/CollectionDeclaration.go
@@ -4,7 +4,7 @@ package sifxml
 type CollectionDeclarations []CollectionDeclaration
 
     type CollectionDeclaration struct {
-  collectiondeclaration `xml:"CollectionDeclaration" json:"CollectionDeclaration"`
+  collectiondeclaration `xml:"CollectionDeclaration"`
 }
 
 type collectiondeclaration struct {

--- a/sifxml/CollectionRound.go
+++ b/sifxml/CollectionRound.go
@@ -4,7 +4,7 @@ package sifxml
 type CollectionRounds []CollectionRound
 
     type CollectionRound struct {
-  collectionround `xml:"CollectionRound" json:"CollectionRound"`
+  collectionround `xml:"CollectionRound"`
 }
 
 type collectionround struct {

--- a/sifxml/CollectionStatus.go
+++ b/sifxml/CollectionStatus.go
@@ -4,7 +4,7 @@ package sifxml
 type CollectionStatuss []CollectionStatus
 
     type CollectionStatus struct {
-  collectionstatus `xml:"CollectionStatus" json:"CollectionStatus"`
+  collectionstatus `xml:"CollectionStatus"`
 }
 
 type collectionstatus struct {

--- a/sifxml/Debtor.go
+++ b/sifxml/Debtor.go
@@ -4,7 +4,7 @@ package sifxml
 type Debtors []Debtor
 
     type Debtor struct {
-  debtor `xml:"Debtor" json:"Debtor"`
+  debtor `xml:"Debtor"`
 }
 
 type debtor struct {
@@ -25,7 +25,7 @@ type debtor struct {
       }
     
 type Debtor_BilledEntity struct {
-  debtor_billedentity `xml:"Debtor_BilledEntity" json:"Debtor_BilledEntity"`
+  debtor_billedentity `xml:"Debtor_BilledEntity"`
 }
 
 type debtor_billedentity struct {

--- a/sifxml/EquipmentInfo.go
+++ b/sifxml/EquipmentInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type EquipmentInfos []EquipmentInfo
 
     type EquipmentInfo struct {
-  equipmentinfo `xml:"EquipmentInfo" json:"EquipmentInfo"`
+  equipmentinfo `xml:"EquipmentInfo"`
 }
 
 type equipmentinfo struct {
@@ -24,7 +24,7 @@ type equipmentinfo struct {
       }
     
 type EquipmentInfo_SIF_RefId struct {
-  equipmentinfo_sif_refid `xml:"EquipmentInfo_SIF_RefId" json:"EquipmentInfo_SIF_RefId"`
+  equipmentinfo_sif_refid `xml:"EquipmentInfo_SIF_RefId"`
 }
 
 type equipmentinfo_sif_refid struct {

--- a/sifxml/FinancialAccount.go
+++ b/sifxml/FinancialAccount.go
@@ -4,7 +4,7 @@ package sifxml
 type FinancialAccounts []FinancialAccount
 
     type FinancialAccount struct {
-  financialaccount `xml:"FinancialAccount" json:"FinancialAccount"`
+  financialaccount `xml:"FinancialAccount"`
 }
 
 type financialaccount struct {

--- a/sifxml/FinancialQuestionnaireCollection.go
+++ b/sifxml/FinancialQuestionnaireCollection.go
@@ -4,7 +4,7 @@ package sifxml
 type FinancialQuestionnaireCollections []FinancialQuestionnaireCollection
 
     type FinancialQuestionnaireCollection struct {
-  financialquestionnairecollection `xml:"FinancialQuestionnaireCollection" json:"FinancialQuestionnaireCollection"`
+  financialquestionnairecollection `xml:"FinancialQuestionnaireCollection"`
 }
 
 type financialquestionnairecollection struct {

--- a/sifxml/GradingAssignment.go
+++ b/sifxml/GradingAssignment.go
@@ -4,7 +4,7 @@ package sifxml
 type GradingAssignments []GradingAssignment
 
     type GradingAssignment struct {
-  gradingassignment `xml:"GradingAssignment" json:"GradingAssignment"`
+  gradingassignment `xml:"GradingAssignment"`
 }
 
 type gradingassignment struct {

--- a/sifxml/GradingAssignmentScore.go
+++ b/sifxml/GradingAssignmentScore.go
@@ -4,7 +4,7 @@ package sifxml
 type GradingAssignmentScores []GradingAssignmentScore
 
     type GradingAssignmentScore struct {
-  gradingassignmentscore `xml:"GradingAssignmentScore" json:"GradingAssignmentScore"`
+  gradingassignmentscore `xml:"GradingAssignmentScore"`
 }
 
 type gradingassignmentscore struct {

--- a/sifxml/Identity.go
+++ b/sifxml/Identity.go
@@ -4,7 +4,7 @@ package sifxml
 type Identitys []Identity
 
     type Identity struct {
-  identity `xml:"Identity" json:"Identity"`
+  identity `xml:"Identity"`
 }
 
 type identity struct {
@@ -21,7 +21,7 @@ type identity struct {
       }
     
 type Identity_SIF_RefId struct {
-  identity_sif_refid `xml:"Identity_SIF_RefId" json:"Identity_SIF_RefId"`
+  identity_sif_refid `xml:"Identity_SIF_RefId"`
 }
 
 type identity_sif_refid struct {

--- a/sifxml/Invoice.go
+++ b/sifxml/Invoice.go
@@ -4,7 +4,7 @@ package sifxml
 type Invoices []Invoice
 
     type Invoice struct {
-  invoice `xml:"Invoice" json:"Invoice"`
+  invoice `xml:"Invoice"`
 }
 
 type invoice struct {
@@ -38,7 +38,7 @@ type invoice struct {
       }
     
 type Invoice_InvoicedEntity struct {
-  invoice_invoicedentity `xml:"Invoice_InvoicedEntity" json:"Invoice_InvoicedEntity"`
+  invoice_invoicedentity `xml:"Invoice_InvoicedEntity"`
 }
 
 type invoice_invoicedentity struct {

--- a/sifxml/Journal.go
+++ b/sifxml/Journal.go
@@ -4,7 +4,7 @@ package sifxml
 type Journals []Journal
 
     type Journal struct {
-  journal `xml:"Journal" json:"Journal"`
+  journal `xml:"Journal"`
 }
 
 type journal struct {
@@ -31,7 +31,7 @@ type journal struct {
       }
     
 type Journal_OriginatingTransactionRefId struct {
-  journal_originatingtransactionrefid `xml:"Journal_OriginatingTransactionRefId" json:"Journal_OriginatingTransactionRefId"`
+  journal_originatingtransactionrefid `xml:"Journal_OriginatingTransactionRefId"`
 }
 
 type journal_originatingtransactionrefid struct {

--- a/sifxml/LEAInfo.go
+++ b/sifxml/LEAInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type LEAInfos []LEAInfo
 
     type LEAInfo struct {
-  leainfo `xml:"LEAInfo" json:"LEAInfo"`
+  leainfo `xml:"LEAInfo"`
 }
 
 type leainfo struct {

--- a/sifxml/LearningResource.go
+++ b/sifxml/LearningResource.go
@@ -4,7 +4,7 @@ package sifxml
 type LearningResources []LearningResource
 
     type LearningResource struct {
-  learningresource `xml:"LearningResource" json:"LearningResource"`
+  learningresource `xml:"LearningResource"`
 }
 
 type learningresource struct {

--- a/sifxml/LearningStandardDocument.go
+++ b/sifxml/LearningStandardDocument.go
@@ -4,7 +4,7 @@ package sifxml
 type LearningStandardDocuments []LearningStandardDocument
 
     type LearningStandardDocument struct {
-  learningstandarddocument `xml:"LearningStandardDocument" json:"LearningStandardDocument"`
+  learningstandarddocument `xml:"LearningStandardDocument"`
 }
 
 type learningstandarddocument struct {

--- a/sifxml/LearningStandardItem.go
+++ b/sifxml/LearningStandardItem.go
@@ -4,7 +4,7 @@ package sifxml
 type LearningStandardItems []LearningStandardItem
 
     type LearningStandardItem struct {
-  learningstandarditem `xml:"LearningStandardItem" json:"LearningStandardItem"`
+  learningstandarditem `xml:"LearningStandardItem"`
 }
 
 type learningstandarditem struct {

--- a/sifxml/LibraryPatronStatus.go
+++ b/sifxml/LibraryPatronStatus.go
@@ -4,7 +4,7 @@ package sifxml
 type LibraryPatronStatuss []LibraryPatronStatus
 
     type LibraryPatronStatus struct {
-  librarypatronstatus `xml:"LibraryPatronStatus" json:"LibraryPatronStatus"`
+  librarypatronstatus `xml:"LibraryPatronStatus"`
 }
 
 type librarypatronstatus struct {

--- a/sifxml/MarkValueInfo.go
+++ b/sifxml/MarkValueInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type MarkValueInfos []MarkValueInfo
 
     type MarkValueInfo struct {
-  markvalueinfo `xml:"MarkValueInfo" json:"MarkValueInfo"`
+  markvalueinfo `xml:"MarkValueInfo"`
 }
 
 type markvalueinfo struct {

--- a/sifxml/NAPCodeFrame.go
+++ b/sifxml/NAPCodeFrame.go
@@ -4,7 +4,7 @@ package sifxml
 type NAPCodeFrames []NAPCodeFrame
 
     type NAPCodeFrame struct {
-  napcodeframe `xml:"NAPCodeFrame" json:"NAPCodeFrame"`
+  napcodeframe `xml:"NAPCodeFrame"`
 }
 
 type napcodeframe struct {

--- a/sifxml/NAPEventStudentLink.go
+++ b/sifxml/NAPEventStudentLink.go
@@ -4,7 +4,7 @@ package sifxml
 type NAPEventStudentLinks []NAPEventStudentLink
 
     type NAPEventStudentLink struct {
-  napeventstudentlink `xml:"NAPEventStudentLink" json:"NAPEventStudentLink"`
+  napeventstudentlink `xml:"NAPEventStudentLink"`
 }
 
 type napeventstudentlink struct {

--- a/sifxml/NAPStudentResponseSet.go
+++ b/sifxml/NAPStudentResponseSet.go
@@ -4,7 +4,7 @@ package sifxml
 type NAPStudentResponseSets []NAPStudentResponseSet
 
     type NAPStudentResponseSet struct {
-  napstudentresponseset `xml:"NAPStudentResponseSet" json:"NAPStudentResponseSet"`
+  napstudentresponseset `xml:"NAPStudentResponseSet"`
 }
 
 type napstudentresponseset struct {

--- a/sifxml/NAPTest.go
+++ b/sifxml/NAPTest.go
@@ -4,7 +4,7 @@ package sifxml
 type NAPTests []NAPTest
 
     type NAPTest struct {
-  naptest `xml:"NAPTest" json:"NAPTest"`
+  naptest `xml:"NAPTest"`
 }
 
 type naptest struct {

--- a/sifxml/NAPTestItem.go
+++ b/sifxml/NAPTestItem.go
@@ -4,7 +4,7 @@ package sifxml
 type NAPTestItems []NAPTestItem
 
     type NAPTestItem struct {
-  naptestitem `xml:"NAPTestItem" json:"NAPTestItem"`
+  naptestitem `xml:"NAPTestItem"`
 }
 
 type naptestitem struct {

--- a/sifxml/NAPTestScoreSummary.go
+++ b/sifxml/NAPTestScoreSummary.go
@@ -4,7 +4,7 @@ package sifxml
 type NAPTestScoreSummarys []NAPTestScoreSummary
 
     type NAPTestScoreSummary struct {
-  naptestscoresummary `xml:"NAPTestScoreSummary" json:"NAPTestScoreSummary"`
+  naptestscoresummary `xml:"NAPTestScoreSummary"`
 }
 
 type naptestscoresummary struct {

--- a/sifxml/NAPTestlet.go
+++ b/sifxml/NAPTestlet.go
@@ -4,7 +4,7 @@ package sifxml
 type NAPTestlets []NAPTestlet
 
     type NAPTestlet struct {
-  naptestlet `xml:"NAPTestlet" json:"NAPTestlet"`
+  naptestlet `xml:"NAPTestlet"`
 }
 
 type naptestlet struct {

--- a/sifxml/PaymentReceipt.go
+++ b/sifxml/PaymentReceipt.go
@@ -4,7 +4,7 @@ package sifxml
 type PaymentReceipts []PaymentReceipt
 
     type PaymentReceipt struct {
-  paymentreceipt `xml:"PaymentReceipt" json:"PaymentReceipt"`
+  paymentreceipt `xml:"PaymentReceipt"`
 }
 
 type paymentreceipt struct {

--- a/sifxml/PersonPicture.go
+++ b/sifxml/PersonPicture.go
@@ -4,7 +4,7 @@ package sifxml
 type PersonPictures []PersonPicture
 
     type PersonPicture struct {
-  personpicture `xml:"PersonPicture" json:"PersonPicture"`
+  personpicture `xml:"PersonPicture"`
 }
 
 type personpicture struct {
@@ -21,7 +21,7 @@ type personpicture struct {
       }
     
 type PersonPicture_ParentObjectRefId struct {
-  personpicture_parentobjectrefid `xml:"PersonPicture_ParentObjectRefId" json:"PersonPicture_ParentObjectRefId"`
+  personpicture_parentobjectrefid `xml:"PersonPicture_ParentObjectRefId"`
 }
 
 type personpicture_parentobjectrefid struct {

--- a/sifxml/PersonPrivacyObligationDocument.go
+++ b/sifxml/PersonPrivacyObligationDocument.go
@@ -4,7 +4,7 @@ package sifxml
 type PersonPrivacyObligationDocuments []PersonPrivacyObligationDocument
 
     type PersonPrivacyObligationDocument struct {
-  personprivacyobligationdocument `xml:"PersonPrivacyObligationDocument" json:"PersonPrivacyObligationDocument"`
+  personprivacyobligationdocument `xml:"PersonPrivacyObligationDocument"`
 }
 
 type personprivacyobligationdocument struct {

--- a/sifxml/PersonalisedPlan.go
+++ b/sifxml/PersonalisedPlan.go
@@ -4,7 +4,7 @@ package sifxml
 type PersonalisedPlans []PersonalisedPlan
 
     type PersonalisedPlan struct {
-  personalisedplan `xml:"PersonalisedPlan" json:"PersonalisedPlan"`
+  personalisedplan `xml:"PersonalisedPlan"`
 }
 
 type personalisedplan struct {

--- a/sifxml/PurchaseOrder.go
+++ b/sifxml/PurchaseOrder.go
@@ -4,7 +4,7 @@ package sifxml
 type PurchaseOrders []PurchaseOrder
 
     type PurchaseOrder struct {
-  purchaseorder `xml:"PurchaseOrder" json:"PurchaseOrder"`
+  purchaseorder `xml:"PurchaseOrder"`
 }
 
 type purchaseorder struct {

--- a/sifxml/ResourceBooking.go
+++ b/sifxml/ResourceBooking.go
@@ -4,7 +4,7 @@ package sifxml
 type ResourceBookings []ResourceBooking
 
     type ResourceBooking struct {
-  resourcebooking `xml:"ResourceBooking" json:"ResourceBooking"`
+  resourcebooking `xml:"ResourceBooking"`
 }
 
 type resourcebooking struct {
@@ -26,7 +26,7 @@ type resourcebooking struct {
       }
     
 type ResourceBooking_ResourceRefId struct {
-  resourcebooking_resourcerefid `xml:"ResourceBooking_ResourceRefId" json:"ResourceBooking_ResourceRefId"`
+  resourcebooking_resourcerefid `xml:"ResourceBooking_ResourceRefId"`
 }
 
 type resourcebooking_resourcerefid struct {

--- a/sifxml/RoomInfo.go
+++ b/sifxml/RoomInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type RoomInfos []RoomInfo
 
     type RoomInfo struct {
-  roominfo `xml:"RoomInfo" json:"RoomInfo"`
+  roominfo `xml:"RoomInfo"`
 }
 
 type roominfo struct {

--- a/sifxml/ScheduledActivity.go
+++ b/sifxml/ScheduledActivity.go
@@ -4,7 +4,7 @@ package sifxml
 type ScheduledActivitys []ScheduledActivity
 
     type ScheduledActivity struct {
-  scheduledactivity `xml:"ScheduledActivity" json:"ScheduledActivity"`
+  scheduledactivity `xml:"ScheduledActivity"`
 }
 
 type scheduledactivity struct {

--- a/sifxml/SchoolCourseInfo.go
+++ b/sifxml/SchoolCourseInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type SchoolCourseInfos []SchoolCourseInfo
 
     type SchoolCourseInfo struct {
-  schoolcourseinfo `xml:"SchoolCourseInfo" json:"SchoolCourseInfo"`
+  schoolcourseinfo `xml:"SchoolCourseInfo"`
 }
 
 type schoolcourseinfo struct {

--- a/sifxml/SchoolInfo.go
+++ b/sifxml/SchoolInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type SchoolInfos []SchoolInfo
 
     type SchoolInfo struct {
-  schoolinfo `xml:"SchoolInfo" json:"SchoolInfo"`
+  schoolinfo `xml:"SchoolInfo"`
 }
 
 type schoolinfo struct {
@@ -58,7 +58,7 @@ type schoolinfo struct {
       }
     
 type SchoolInfo_OtherLEA struct {
-  schoolinfo_otherlea `xml:"SchoolInfo_OtherLEA" json:"SchoolInfo_OtherLEA"`
+  schoolinfo_otherlea `xml:"SchoolInfo_OtherLEA"`
 }
 
 type schoolinfo_otherlea struct {

--- a/sifxml/SchoolPrograms.go
+++ b/sifxml/SchoolPrograms.go
@@ -4,7 +4,7 @@ package sifxml
 type SchoolProgramss []SchoolPrograms
 
     type SchoolPrograms struct {
-  schoolprograms `xml:"SchoolPrograms" json:"SchoolPrograms"`
+  schoolprograms `xml:"SchoolPrograms"`
 }
 
 type schoolprograms struct {

--- a/sifxml/SectionInfo.go
+++ b/sifxml/SectionInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type SectionInfos []SectionInfo
 
     type SectionInfo struct {
-  sectioninfo `xml:"SectionInfo" json:"SectionInfo"`
+  sectioninfo `xml:"SectionInfo"`
 }
 
 type sectioninfo struct {

--- a/sifxml/SessionInfo.go
+++ b/sifxml/SessionInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type SessionInfos []SessionInfo
 
     type SessionInfo struct {
-  sessioninfo `xml:"SessionInfo" json:"SessionInfo"`
+  sessioninfo `xml:"SessionInfo"`
 }
 
 type sessioninfo struct {

--- a/sifxml/StaffAssignment.go
+++ b/sifxml/StaffAssignment.go
@@ -4,7 +4,7 @@ package sifxml
 type StaffAssignments []StaffAssignment
 
     type StaffAssignment struct {
-  staffassignment `xml:"StaffAssignment" json:"StaffAssignment"`
+  staffassignment `xml:"StaffAssignment"`
 }
 
 type staffassignment struct {

--- a/sifxml/StaffPersonal.go
+++ b/sifxml/StaffPersonal.go
@@ -4,7 +4,7 @@ package sifxml
 type StaffPersonals []StaffPersonal
 
     type StaffPersonal struct {
-  staffpersonal `xml:"StaffPersonal" json:"StaffPersonal"`
+  staffpersonal `xml:"StaffPersonal"`
 }
 
 type staffpersonal struct {

--- a/sifxml/StudentActivityInfo.go
+++ b/sifxml/StudentActivityInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentActivityInfos []StudentActivityInfo
 
     type StudentActivityInfo struct {
-  studentactivityinfo `xml:"StudentActivityInfo" json:"StudentActivityInfo"`
+  studentactivityinfo `xml:"StudentActivityInfo"`
 }
 
 type studentactivityinfo struct {

--- a/sifxml/StudentActivityParticipation.go
+++ b/sifxml/StudentActivityParticipation.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentActivityParticipations []StudentActivityParticipation
 
     type StudentActivityParticipation struct {
-  studentactivityparticipation `xml:"StudentActivityParticipation" json:"StudentActivityParticipation"`
+  studentactivityparticipation `xml:"StudentActivityParticipation"`
 }
 
 type studentactivityparticipation struct {

--- a/sifxml/StudentAttendanceCollection.go
+++ b/sifxml/StudentAttendanceCollection.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentAttendanceCollections []StudentAttendanceCollection
 
     type StudentAttendanceCollection struct {
-  studentattendancecollection `xml:"StudentAttendanceCollection" json:"StudentAttendanceCollection"`
+  studentattendancecollection `xml:"StudentAttendanceCollection"`
 }
 
 type studentattendancecollection struct {

--- a/sifxml/StudentAttendanceSummary.go
+++ b/sifxml/StudentAttendanceSummary.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentAttendanceSummarys []StudentAttendanceSummary
 
     type StudentAttendanceSummary struct {
-  studentattendancesummary `xml:"StudentAttendanceSummary" json:"StudentAttendanceSummary"`
+  studentattendancesummary `xml:"StudentAttendanceSummary"`
 }
 
 type studentattendancesummary struct {

--- a/sifxml/StudentAttendanceTimeList.go
+++ b/sifxml/StudentAttendanceTimeList.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentAttendanceTimeLists []StudentAttendanceTimeList
 
     type StudentAttendanceTimeList struct {
-  studentattendancetimelist `xml:"StudentAttendanceTimeList" json:"StudentAttendanceTimeList"`
+  studentattendancetimelist `xml:"StudentAttendanceTimeList"`
 }
 
 type studentattendancetimelist struct {

--- a/sifxml/StudentContactPersonal.go
+++ b/sifxml/StudentContactPersonal.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentContactPersonals []StudentContactPersonal
 
     type StudentContactPersonal struct {
-  studentcontactpersonal `xml:"StudentContactPersonal" json:"StudentContactPersonal"`
+  studentcontactpersonal `xml:"StudentContactPersonal"`
 }
 
 type studentcontactpersonal struct {

--- a/sifxml/StudentContactRelationship.go
+++ b/sifxml/StudentContactRelationship.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentContactRelationships []StudentContactRelationship
 
     type StudentContactRelationship struct {
-  studentcontactrelationship `xml:"StudentContactRelationship" json:"StudentContactRelationship"`
+  studentcontactrelationship `xml:"StudentContactRelationship"`
 }
 
 type studentcontactrelationship struct {

--- a/sifxml/StudentDailyAttendance.go
+++ b/sifxml/StudentDailyAttendance.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentDailyAttendances []StudentDailyAttendance
 
     type StudentDailyAttendance struct {
-  studentdailyattendance `xml:"StudentDailyAttendance" json:"StudentDailyAttendance"`
+  studentdailyattendance `xml:"StudentDailyAttendance"`
 }
 
 type studentdailyattendance struct {

--- a/sifxml/StudentDataTransferNote.go
+++ b/sifxml/StudentDataTransferNote.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentDataTransferNotes []StudentDataTransferNote
 
     type StudentDataTransferNote struct {
-  studentdatatransfernote `xml:"StudentDataTransferNote" json:"StudentDataTransferNote"`
+  studentdatatransfernote `xml:"StudentDataTransferNote"`
 }
 
 type studentdatatransfernote struct {

--- a/sifxml/StudentGrade.go
+++ b/sifxml/StudentGrade.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentGrades []StudentGrade
 
     type StudentGrade struct {
-  studentgrade `xml:"StudentGrade" json:"StudentGrade"`
+  studentgrade `xml:"StudentGrade"`
 }
 
 type studentgrade struct {

--- a/sifxml/StudentParticipation.go
+++ b/sifxml/StudentParticipation.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentParticipations []StudentParticipation
 
     type StudentParticipation struct {
-  studentparticipation `xml:"StudentParticipation" json:"StudentParticipation"`
+  studentparticipation `xml:"StudentParticipation"`
 }
 
 type studentparticipation struct {
@@ -42,7 +42,7 @@ type studentparticipation struct {
       }
     
 type StudentParticipation_ManagingSchool struct {
-  studentparticipation_managingschool `xml:"StudentParticipation_ManagingSchool" json:"StudentParticipation_ManagingSchool"`
+  studentparticipation_managingschool `xml:"StudentParticipation_ManagingSchool"`
 }
 
 type studentparticipation_managingschool struct {

--- a/sifxml/StudentPeriodAttendance.go
+++ b/sifxml/StudentPeriodAttendance.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentPeriodAttendances []StudentPeriodAttendance
 
     type StudentPeriodAttendance struct {
-  studentperiodattendance `xml:"StudentPeriodAttendance" json:"StudentPeriodAttendance"`
+  studentperiodattendance `xml:"StudentPeriodAttendance"`
 }
 
 type studentperiodattendance struct {

--- a/sifxml/StudentPersonal.go
+++ b/sifxml/StudentPersonal.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentPersonals []StudentPersonal
 
     type StudentPersonal struct {
-  studentpersonal `xml:"StudentPersonal" json:"StudentPersonal"`
+  studentpersonal `xml:"StudentPersonal"`
 }
 
 type studentpersonal struct {

--- a/sifxml/StudentSchoolEnrollment.go
+++ b/sifxml/StudentSchoolEnrollment.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentSchoolEnrollments []StudentSchoolEnrollment
 
     type StudentSchoolEnrollment struct {
-  studentschoolenrollment `xml:"StudentSchoolEnrollment" json:"StudentSchoolEnrollment"`
+  studentschoolenrollment `xml:"StudentSchoolEnrollment"`
 }
 
 type studentschoolenrollment struct {
@@ -61,7 +61,7 @@ type studentschoolenrollment struct {
       }
     
 type StudentSchoolEnrollment_Calendar struct {
-  studentschoolenrollment_calendar `xml:"StudentSchoolEnrollment_Calendar" json:"StudentSchoolEnrollment_Calendar"`
+  studentschoolenrollment_calendar `xml:"StudentSchoolEnrollment_Calendar"`
 }
 
 type studentschoolenrollment_calendar struct {

--- a/sifxml/StudentScoreJudgementAgainstStandard.go
+++ b/sifxml/StudentScoreJudgementAgainstStandard.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentScoreJudgementAgainstStandards []StudentScoreJudgementAgainstStandard
 
     type StudentScoreJudgementAgainstStandard struct {
-  studentscorejudgementagainststandard `xml:"StudentScoreJudgementAgainstStandard" json:"StudentScoreJudgementAgainstStandard"`
+  studentscorejudgementagainststandard `xml:"StudentScoreJudgementAgainstStandard"`
 }
 
 type studentscorejudgementagainststandard struct {

--- a/sifxml/StudentSectionEnrollment.go
+++ b/sifxml/StudentSectionEnrollment.go
@@ -4,7 +4,7 @@ package sifxml
 type StudentSectionEnrollments []StudentSectionEnrollment
 
     type StudentSectionEnrollment struct {
-  studentsectionenrollment `xml:"StudentSectionEnrollment" json:"StudentSectionEnrollment"`
+  studentsectionenrollment `xml:"StudentSectionEnrollment"`
 }
 
 type studentsectionenrollment struct {

--- a/sifxml/TeachingGroup.go
+++ b/sifxml/TeachingGroup.go
@@ -4,7 +4,7 @@ package sifxml
 type TeachingGroups []TeachingGroup
 
     type TeachingGroup struct {
-  teachinggroup `xml:"TeachingGroup" json:"TeachingGroup"`
+  teachinggroup `xml:"TeachingGroup"`
 }
 
 type teachinggroup struct {

--- a/sifxml/TermInfo.go
+++ b/sifxml/TermInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type TermInfos []TermInfo
 
     type TermInfo struct {
-  terminfo `xml:"TermInfo" json:"TermInfo"`
+  terminfo `xml:"TermInfo"`
 }
 
 type terminfo struct {

--- a/sifxml/TimeTable.go
+++ b/sifxml/TimeTable.go
@@ -4,7 +4,7 @@ package sifxml
 type TimeTables []TimeTable
 
     type TimeTable struct {
-  timetable `xml:"TimeTable" json:"TimeTable"`
+  timetable `xml:"TimeTable"`
 }
 
 type timetable struct {

--- a/sifxml/TimeTableCell.go
+++ b/sifxml/TimeTableCell.go
@@ -4,7 +4,7 @@ package sifxml
 type TimeTableCells []TimeTableCell
 
     type TimeTableCell struct {
-  timetablecell `xml:"TimeTableCell" json:"TimeTableCell"`
+  timetablecell `xml:"TimeTableCell"`
 }
 
 type timetablecell struct {

--- a/sifxml/TimeTableContainer.go
+++ b/sifxml/TimeTableContainer.go
@@ -4,7 +4,7 @@ package sifxml
 type TimeTableContainers []TimeTableContainer
 
     type TimeTableContainer struct {
-  timetablecontainer `xml:"TimeTableContainer" json:"TimeTableContainer"`
+  timetablecontainer `xml:"TimeTableContainer"`
 }
 
 type timetablecontainer struct {

--- a/sifxml/TimeTableSubject.go
+++ b/sifxml/TimeTableSubject.go
@@ -4,7 +4,7 @@ package sifxml
 type TimeTableSubjects []TimeTableSubject
 
     type TimeTableSubject struct {
-  timetablesubject `xml:"TimeTableSubject" json:"TimeTableSubject"`
+  timetablesubject `xml:"TimeTableSubject"`
 }
 
 type timetablesubject struct {

--- a/sifxml/VendorInfo.go
+++ b/sifxml/VendorInfo.go
@@ -4,7 +4,7 @@ package sifxml
 type VendorInfos []VendorInfo
 
     type VendorInfo struct {
-  vendorinfo `xml:"VendorInfo" json:"VendorInfo"`
+  vendorinfo `xml:"VendorInfo"`
 }
 
 type vendorinfo struct {

--- a/sifxml/WellbeingAlert.go
+++ b/sifxml/WellbeingAlert.go
@@ -4,7 +4,7 @@ package sifxml
 type WellbeingAlerts []WellbeingAlert
 
     type WellbeingAlert struct {
-  wellbeingalert `xml:"WellbeingAlert" json:"WellbeingAlert"`
+  wellbeingalert `xml:"WellbeingAlert"`
 }
 
 type wellbeingalert struct {

--- a/sifxml/WellbeingAppeal.go
+++ b/sifxml/WellbeingAppeal.go
@@ -4,7 +4,7 @@ package sifxml
 type WellbeingAppeals []WellbeingAppeal
 
     type WellbeingAppeal struct {
-  wellbeingappeal `xml:"WellbeingAppeal" json:"WellbeingAppeal"`
+  wellbeingappeal `xml:"WellbeingAppeal"`
 }
 
 type wellbeingappeal struct {

--- a/sifxml/WellbeingCharacteristic.go
+++ b/sifxml/WellbeingCharacteristic.go
@@ -4,7 +4,7 @@ package sifxml
 type WellbeingCharacteristics []WellbeingCharacteristic
 
     type WellbeingCharacteristic struct {
-  wellbeingcharacteristic `xml:"WellbeingCharacteristic" json:"WellbeingCharacteristic"`
+  wellbeingcharacteristic `xml:"WellbeingCharacteristic"`
 }
 
 type wellbeingcharacteristic struct {

--- a/sifxml/WellbeingEvent.go
+++ b/sifxml/WellbeingEvent.go
@@ -4,7 +4,7 @@ package sifxml
 type WellbeingEvents []WellbeingEvent
 
     type WellbeingEvent struct {
-  wellbeingevent `xml:"WellbeingEvent" json:"WellbeingEvent"`
+  wellbeingevent `xml:"WellbeingEvent"`
 }
 
 type wellbeingevent struct {

--- a/sifxml/WellbeingPersonLink.go
+++ b/sifxml/WellbeingPersonLink.go
@@ -4,7 +4,7 @@ package sifxml
 type WellbeingPersonLinks []WellbeingPersonLink
 
     type WellbeingPersonLink struct {
-  wellbeingpersonlink `xml:"WellbeingPersonLink" json:"WellbeingPersonLink"`
+  wellbeingpersonlink `xml:"WellbeingPersonLink"`
 }
 
 type wellbeingpersonlink struct {
@@ -27,7 +27,7 @@ type wellbeingpersonlink struct {
       }
     
 type WellbeingPersonLink_PersonRefId struct {
-  wellbeingpersonlink_personrefid `xml:"WellbeingPersonLink_PersonRefId" json:"WellbeingPersonLink_PersonRefId"`
+  wellbeingpersonlink_personrefid `xml:"WellbeingPersonLink_PersonRefId"`
 }
 
 type wellbeingpersonlink_personrefid struct {

--- a/sifxml/WellbeingResponse.go
+++ b/sifxml/WellbeingResponse.go
@@ -4,7 +4,7 @@ package sifxml
 type WellbeingResponses []WellbeingResponse
 
     type WellbeingResponse struct {
-  wellbeingresponse `xml:"WellbeingResponse" json:"WellbeingResponse"`
+  wellbeingresponse `xml:"WellbeingResponse"`
 }
 
 type wellbeingresponse struct {


### PR DESCRIPTION
Implements the simpler option proposed in #11 (removing the json tag from the embedded struct, leaving the xml tag as-is) by tweaking the `struct2go2.pl` script and regenerating all relevant files within the `sifxml` directory.

Closes #11 